### PR TITLE
Fixed path to devbox_dir

### DIFF
--- a/init_project.sh
+++ b/init_project.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-devbox_dir=$PWD
+devbox_dir=$(cd `dirname $0` && pwd)
 
 source "${devbox_dir}/scripts/functions.sh"
 resetNestingLevel


### PR DESCRIPTION
This fix allows to run the `init_project.sh` script from any directory (DevBox directory is fixed and is always relative to the `init_project.sh` script).